### PR TITLE
fixed usernames across websockets

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -61,9 +61,8 @@ io.on("connection", (socket) => {
         players = players.filter((p) => p.id != socket.id);
         io.emit("disconnected", players);
     });
-    socket.on("chat message", async (input) => {
-        console.log("Received message!");
-        io.emit("chat message", input);
+    socket.on("chat message", async (input, username) => {
+        io.emit("chat message", input, username);
 
         // Save message to Firestore because funny haha
         try {

--- a/frontend/components/Broadcast.jsx
+++ b/frontend/components/Broadcast.jsx
@@ -38,9 +38,9 @@ export default function Broadcast() {
     useEffect(() => {
         if (!socket) return;
 
-        const handleMessage = (msg) => {
-            setMessages((prev) => [...prev, `${username}: ${msg}`]);
-            msgTimeout(`${username}: ${msg}`);
+        const handleMessage = (msg, user) => {
+            setMessages((prev) => [...prev, `${user}: ${msg}`]);
+            msgTimeout(`${user}: ${msg}`);
         };
 
         const handleConnection = () => {
@@ -73,7 +73,7 @@ export default function Broadcast() {
     function handleSubmit(e) {
         e.preventDefault();
         if (inputRef.current.value) {
-            socket.emit("chat message", inputRef.current.value);
+            socket.emit("chat message", inputRef.current.value, username);
             inputRef.current.value = "";
             inputRef.current.blur();
         }


### PR DESCRIPTION
this commit originally just made every single message use your own username. Now the websockets show the username of the sender.